### PR TITLE
Revert "security: harden pod security contexts and move token to env var"

### DIFF
--- a/controller/src/controllers/cache_job/apply_job.rs
+++ b/controller/src/controllers/cache_job/apply_job.rs
@@ -3,14 +3,12 @@ use kubimo::k8s_openapi::api::core::v1::{
     Container, PersistentVolumeClaimVolumeSource, PodSecurityContext, PodSpec, PodTemplateSpec,
     Volume, VolumeMount,
 };
-
 use kubimo::kube::api::ObjectMeta;
 use kubimo::{CacheJob, Workspace, prelude::*};
 
 use crate::command::cmd;
 use crate::context::Context;
 use crate::controllers::indexer;
-use crate::hardened_security_context;
 use crate::resources::Resources;
 
 use super::CacheJobReconciler;
@@ -26,7 +24,6 @@ impl CacheJobReconciler {
         Container {
             name: "cache".into(),
             image: Some(ctx.config.marimo_image.clone()),
-            security_context: Some(hardened_security_context()),
             resources: Resources::default()
                 .cpu(cache_job.spec.cpu.clone())
                 .memory(cache_job.spec.memory.clone())
@@ -51,7 +48,6 @@ impl CacheJobReconciler {
         Ok(Container {
             name: "indexer".to_string(),
             image: Some(ctx.config.marimo_image.clone()),
-            security_context: Some(hardened_security_context()),
             command: Some(cmd!["/app/indexer"]),
             args: Some(indexer::upload_args(workspace, false)?),
             env: indexer::env(workspace),

--- a/controller/src/controllers/runner/apply_pod.rs
+++ b/controller/src/controllers/runner/apply_pod.rs
@@ -1,8 +1,7 @@
 use kubimo::k8s_openapi::api::core::v1::{
-    Container, ContainerPort, EnvVar, HTTPGetAction, PersistentVolumeClaimVolumeSource, Pod,
+    Container, ContainerPort, HTTPGetAction, PersistentVolumeClaimVolumeSource, Pod,
     PodSecurityContext, PodSpec, Probe, Volume, VolumeMount,
 };
-
 use kubimo::k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kubimo::kube::api::ObjectMeta;
 use kubimo::{Runner, RunnerCommand, prelude::*};
@@ -10,7 +9,6 @@ use kubimo::{Runner, RunnerCommand, prelude::*};
 use crate::command::cmd;
 use crate::context::Context;
 use crate::controllers::ingress::ingress_path;
-use crate::hardened_security_context;
 use crate::resources::Resources;
 
 use super::RunnerReconciler;
@@ -30,6 +28,14 @@ impl RunnerReconciler {
             ..Default::default()
         };
         let mut command = cmd!["bash", "/setup/start.sh", "--base-url", ingress_path,];
+        if let Some(token) = runner
+            .spec
+            .token
+            .as_ref()
+            .and_then(|token| token.value.as_ref())
+        {
+            command.extend(cmd!["--token", token]);
+        }
         if let Some(log_level) = runner.spec.log_level.as_ref() {
             command.extend(cmd!["--log-level", log_level]);
         }
@@ -40,22 +46,6 @@ impl RunnerReconciler {
             }
             .into(),
         );
-        let env = if let Some(token) = runner
-            .spec
-            .token
-            .as_ref()
-            .and_then(|token| token.value.as_ref())
-        {
-            let mut env = runner.spec.env.clone().unwrap_or_default();
-            env.push(EnvVar {
-                name: "TOKEN".into(),
-                value: Some(token.clone()),
-                ..Default::default()
-            });
-            Some(env)
-        } else {
-            runner.spec.env.clone()
-        };
         let pod = Pod {
             metadata: ObjectMeta {
                 name: runner.metadata.name.clone(),
@@ -90,8 +80,7 @@ impl RunnerReconciler {
                         name: Some("marimo".to_string()),
                         ..Default::default()
                     }]),
-                    security_context: Some(hardened_security_context()),
-                    env,
+                    env: runner.spec.env.clone(),
                     env_from: runner.spec.env_from.clone(),
                     startup_probe: Some(Probe {
                         http_get: Some(probe_action.clone()),

--- a/controller/src/controllers/workspace/apply_indexer.rs
+++ b/controller/src/controllers/workspace/apply_indexer.rs
@@ -1,15 +1,12 @@
 use kubimo::k8s_openapi::api::core::v1::{
-    Container, PersistentVolumeClaimVolumeSource, Pod, PodSecurityContext, PodSpec, Volume,
-    VolumeMount,
+    Container, PersistentVolumeClaimVolumeSource, Pod, PodSpec, Volume, VolumeMount,
 };
-
 use kubimo::kube::api::ObjectMeta;
 use kubimo::{Expr, FilterParams, Runner, RunnerCommand, RunnerField, Workspace, prelude::*};
 
 use crate::command::cmd;
 use crate::context::Context;
 use crate::controllers::indexer;
-use crate::hardened_security_context;
 
 use super::WorkspaceReconciler;
 
@@ -32,13 +29,8 @@ impl WorkspaceReconciler {
             },
             spec: Some(PodSpec {
                 service_account_name: Some(service_account_name.to_string()),
-                security_context: Some(PodSecurityContext {
-                    fs_group: Some(1000),
-                    ..Default::default()
-                }),
                 containers: vec![Container {
                     name: "indexer".to_string(),
-                    security_context: Some(hardened_security_context()),
                     image: Some(ctx.config.marimo_image.clone()),
                     command: Some(cmd!["/app/indexer"]),
                     args: Some(indexer::upload_args(workspace, true)?),

--- a/controller/src/controllers/workspace/apply_job.rs
+++ b/controller/src/controllers/workspace/apply_job.rs
@@ -3,13 +3,11 @@ use kubimo::k8s_openapi::api::core::v1::{
     Container, PersistentVolumeClaimVolumeSource, PodSecurityContext, PodSpec, PodTemplateSpec,
     Volume, VolumeMount,
 };
-
 use kubimo::kube::api::ObjectMeta;
 use kubimo::{Workspace, prelude::*};
 
 use crate::command::cmd;
 use crate::context::Context;
-use crate::hardened_security_context;
 
 use super::WorkspaceReconciler;
 
@@ -78,7 +76,6 @@ chown -R 1000:1000 /home/me
                         containers: vec![Container {
                             name: "init".into(),
                             image: Some(ctx.config.marimo_image.clone()),
-                            security_context: Some(hardened_security_context()),
                             volume_mounts: Some(vec![VolumeMount {
                                 mount_path: "/home/me".into(),
                                 name: workspace_name.into(),

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -13,4 +13,4 @@ mod utils;
 pub use config::Config;
 pub use context::Context;
 pub use error::{ControllerError, ControllerResult};
-pub use utils::{ControllerStreamExt, hardened_security_context};
+pub use utils::ControllerStreamExt;

--- a/controller/src/utils.rs
+++ b/controller/src/utils.rs
@@ -1,6 +1,5 @@
 use futures::future::BoxFuture;
 use futures::prelude::*;
-use kubimo::k8s_openapi::api::core::v1::{Capabilities, SecurityContext};
 
 pub trait ControllerStreamExt<'a> {
     fn wait(self) -> BoxFuture<'a, ()>;
@@ -13,18 +12,5 @@ where
     fn wait(self) -> BoxFuture<'a, ()> {
         self.for_each_concurrent(None, |_| futures::future::ready(()))
             .boxed()
-    }
-}
-
-pub fn hardened_security_context() -> SecurityContext {
-    SecurityContext {
-        run_as_non_root: Some(true),
-        run_as_user: Some(1000),
-        allow_privilege_escalation: Some(false),
-        capabilities: Some(Capabilities {
-            drop: Some(vec!["ALL".into()]),
-            ..Default::default()
-        }),
-        ..Default::default()
     }
 }


### PR DESCRIPTION
Reverts aqora-io/kubimo#20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated token handling in runner initialization to use command-line arguments instead of alternative mechanisms.
  * Simplified container and pod configuration across cache, indexer, and workspace components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->