### PR TITLE
test: add optional subnet to minikube start

### DIFF
--- a/scripts/setup-minikube.sh
+++ b/scripts/setup-minikube.sh
@@ -3,7 +3,8 @@
 minikube start --container-runtime=containerd \
   --network=minikube \
   --docker-opt containerd=/var/run/containerd/containerd.sock \
-  --addons=ingress,gvisor,metrics-server,dashboard,volumesnapshots,csi-hostpath-driver
+  --addons=ingress,gvisor,metrics-server,dashboard,volumesnapshots,csi-hostpath-driver \
+  ${MINIKUBE_SUBNET:+--subnet=$MINIKUBE_SUBNET}
 
 # Shamelessly copy-pasted from:
 # https://minikube.sigs.k8s.io/docs/tutorials/volume_snapshots_and_csi/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Minikube startup configuration now supports optional subnet specification through an environment variable, enabling more flexible network setup during cluster initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->