### PR TITLE
fix: wait for workspace to be ready before running cache job

### DIFF
--- a/controller/src/controllers/cache_job/apply_owner_reference.rs
+++ b/controller/src/controllers/cache_job/apply_owner_reference.rs
@@ -9,6 +9,7 @@ impl CacheJobReconciler {
         &self,
         ctx: &Context,
         cache_job: &CacheJob,
+        workspace: &Workspace,
     ) -> Result<(), kubimo::Error> {
         let namespace = cache_job.require_namespace()?;
         if !cache_job
@@ -23,10 +24,6 @@ impl CacheJobReconciler {
                 })
             })
         {
-            let workspace = ctx
-                .api_namespaced::<Workspace>(namespace)
-                .get(cache_job.spec.workspace.as_ref())
-                .await?;
             let mut owner_refs = cache_job
                 .metadata
                 .owner_references

--- a/controller/src/controllers/cache_job/mod.rs
+++ b/controller/src/controllers/cache_job/mod.rs
@@ -2,14 +2,16 @@ mod apply_job;
 mod apply_owner_reference;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::prelude::*;
-use kubimo::CacheJob;
 use kubimo::k8s_openapi::api::batch::v1::Job;
 use kubimo::kube::runtime::{Controller, controller::Action};
+use kubimo::{CacheJob, Workspace, prelude::*};
 
 use crate::backoff::default_error_policy;
 use crate::context::Context;
+use crate::controllers::runner::is_workspace_ready;
 use crate::error::ControllerResult;
 use crate::reconciler::{ReconcileError, Reconciler, ReconcilerExt};
 
@@ -22,11 +24,31 @@ impl Reconciler for CacheJobReconciler {
     type Error = kubimo::Error;
 
     async fn apply(&self, ctx: &Context, cache_job: &CacheJob) -> Result<Action, Self::Error> {
-        futures::future::try_join_all([
-            self.apply_owner_reference(ctx, cache_job).boxed(),
-            self.apply_job(ctx, cache_job).map_ok(|_| ()).boxed(),
-        ])
-        .await?;
+        let namespace = cache_job.require_namespace()?;
+        let workspace = ctx
+            .api_namespaced::<Workspace>(namespace)
+            .get_opt(&cache_job.spec.workspace)
+            .await?;
+        // Workspace does not exist
+        let Some(workspace) = workspace else {
+            return Err(kubimo::Error::Custom(format!(
+                "CacheJob bound to workspace that does not exist: {workspace:?}",
+                workspace = cache_job.spec.workspace
+            )));
+        };
+
+        // Set the owner reference before gating on readiness so the CacheJob
+        // is garbage-collected even if the workspace never becomes ready.
+        self.apply_owner_reference(ctx, cache_job, &workspace)
+            .await?;
+
+        // The cache job mounts the workspace volume; running it before the
+        // workspace's init job has populated the volume fails `uv sync`.
+        if !is_workspace_ready(&workspace) {
+            return Ok(Action::requeue(Duration::from_secs(5)));
+        }
+
+        self.apply_job(ctx, cache_job).await?;
         Ok(Action::await_change())
     }
 }

--- a/controller/src/controllers/runner/mod.rs
+++ b/controller/src/controllers/runner/mod.rs
@@ -80,7 +80,7 @@ impl Reconciler for RunnerReconciler {
     }
 }
 
-fn is_workspace_ready(workspace: &Workspace) -> bool {
+pub(crate) fn is_workspace_ready(workspace: &Workspace) -> bool {
     workspace.status.as_ref().is_some_and(|status| {
         status
             .conditions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal control flow for cache job reconciliation to better handle workspace readiness checks and owner reference setup sequentially rather than concurrently.
  * Enhanced workspace resource resolution during cache job operations for more robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->