### PR TITLE
fix: use sandbox for marimo

### DIFF
--- a/docker/setup/launch.py
+++ b/docker/setup/launch.py
@@ -1,8 +1,10 @@
-import os
-import pwd
 import sys
 
-home_dir = pwd.getpwuid(os.getuid()).pw_dir
+# Pin the marimo server to the image's patched build: this script runs on the
+# workspace venv interpreter, and the venv contains its own stock marimo that
+# would otherwise shadow the image's (losing the SSR/export patches). Notebook
+# kernels are unaffected — with --sandbox they run as IPC subprocesses on the
+# workspace venv with its normal venv-first path.
 system_sites = [site_dir for site_dir in sys.path if site_dir.startswith("/usr")]
 other_sites = [site_dir for site_dir in sys.path if not site_dir.startswith("/usr")]
 sys.path = [*system_sites, *other_sites]

--- a/docker/setup/pyproject.toml
+++ b/docker/setup/pyproject.toml
@@ -19,3 +19,7 @@ dev = [
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
+
+[tool.marimo.venv]
+path = "/home/me/venv"
+writable = true

--- a/docker/setup/start.sh
+++ b/docker/setup/start.sh
@@ -72,12 +72,39 @@ else
   marimo_flags+=("--token-password=$TOKEN")
 fi
 
+# Workspace content created before the template included [tool.marimo.venv]
+# needs the table, otherwise --sandbox builds an ephemeral sandbox per
+# notebook instead of using the workspace venv.
+ensure_marimo_venv_config() {
+  if [ -f pyproject.toml ] && ! python3 -c '
+import sys, tomllib
+with open("pyproject.toml", "rb") as f:
+    data = tomllib.load(f)
+# Check for the table itself, not a key inside it: appending a duplicate
+# [tool.marimo.venv] header would be invalid TOML.
+sys.exit(0 if "venv" in data.get("tool", {}).get("marimo", {}) else 1)
+'; then
+    cat >>pyproject.toml <<TOML
+
+[tool.marimo.venv]
+path = "$VIRTUAL_ENV"
+writable = true
+TOML
+  fi
+}
+
+# --sandbox on a directory makes marimo spawn each kernel as an IPC subprocess
+# on the workspace venv (see [tool.marimo.venv] in the template pyproject), so
+# user-installed packages aren't shadowed by the image's system site-packages
+# that launch.py prioritizes for the server.
 if [[ "$CMD" == "edit" ]]; then
   uv sync
+  ensure_marimo_venv_config
   exec "$VIRTUAL_ENV/bin/python3" /setup/launch.py \
     "${common_flags[@]}" \
     --yes \
     edit \
+    --sandbox \
     --skip-update-check \
     --headless \
     --watch \
@@ -87,10 +114,12 @@ if [[ "$CMD" == "edit" ]]; then
 
 elif [[ "$CMD" == "run" ]]; then
   uv sync
+  ensure_marimo_venv_config
   exec "$VIRTUAL_ENV/bin/python3" /setup/launch.py \
     "${common_flags[@]}" \
     --yes \
     run \
+    --sandbox \
     --headless \
     --watch \
     --allow-origins='*' \


### PR DESCRIPTION
Necessary because otherwise it would be impossible to upgrade the `aqora` python package or any packages associated with `aqora` or `marimo`. The sandbox keeps the virtual environment isolated from marimo which was the initial reason for the change in path ordering